### PR TITLE
chore: update regex for WSL

### DIFF
--- a/src/Functions.test.ts
+++ b/src/Functions.test.ts
@@ -3,7 +3,8 @@ import Functions from "./Functions";
 describe("DD file to data test", () => {
     it.each([
         ["dd_OPN2102T_12032021_023052.zip", "OPN2102T", "dd"],
-        ["dd_LMS2101_AA1_27042021_043113.zip", "LMS2101_AA1", "dd"]
+        ["dd_LMS2101_AA1_27042021_043113.zip", "LMS2101_AA1", "dd"],
+        ["dd_WLS2301_19012023_155829.zip", "WLS2301", "dd"]
     ])("should return the prefix and instrumentName", (filename, instrumentName, prefix) => {
         const file_data = Functions.dd_filename_to_data(filename);
         expect(file_data.instrumentName).toBe(instrumentName);

--- a/src/Functions.ts
+++ b/src/Functions.ts
@@ -23,7 +23,7 @@ function generateDateFromString(dateString: string, timeString: string): DateTyp
 }
 
 export function dd_filename_to_data(dd_filename: string): DataDeliveryFile {
-    if (!dd_filename.match(/^[a-zA-Z]{2}_.{8,}_[0-9]{8}_[0-9]{4,}/)) {
+    if (!dd_filename.match(/^[a-zA-Z]{2}_.{8,}_?[0-9]{8}_[0-9]{4,}/)) {
         return {
             prefix: "dd",
             instrumentName: dd_filename,


### PR DESCRIPTION
REGEX expression does not currently capture WSL surveys as they as in the format dd_WSL1234_122345678_123456.zip. Currently, the REGEX expects two '_'.

refs: BLAIS5-3600